### PR TITLE
Title text does not contain markup.

### DIFF
--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -45,7 +45,7 @@
                 var itemCount = 0;
                 $respTabs.find('.resp-accordion').each(function () {
                     $tabItemh2 = $(this);
-                    var innertext = $respTabs.find('.resp-tab-item:eq(' + itemCount + ')').text();
+                    var innertext = $respTabs.find('.resp-tab-item:eq(' + itemCount + ')').html();
                     $respTabs.find('.resp-accordion:eq(' + itemCount + ')').append(innertext);
                     $tabItemh2.attr('aria-controls', 'tab_item-' + (itemCount));
                     itemCount++;


### PR DESCRIPTION
When the tabs get turned to accordions the titles don't retain their markup.  It's important that they do.  One line easy fix.
