### PR TITLE
Converted CSS to Sass/SCSS

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -9,8 +9,15 @@
     <script src="js/jquery-1.6.3.min.js"></script>
     <script src="js/easyResponsiveTabs.js" type="text/javascript"></script>
     <style type="text/css">
+        body {
+            margin: 0px;
+            padding: 0px;
+            background: #f5f5f5;
+            font-family: 'Segoe UI';
+        }
+
         .demo {
-            width: 980px;
+            max-width: 980px;
             margin: 0px auto;
         }
         .demo h1 {
@@ -18,6 +25,9 @@
             }
         .demo h3 {
                 margin: 10px 0;
+            }
+        .demo p {
+                margin: 0;
             }
         pre {
             background: #fff;
@@ -69,6 +79,17 @@
                 </div>
                 <div>
                     <p>Suspendisse blandit velit Integer laoreet placerat suscipit. Sed sodales scelerisque commodo. Nam porta cursus lectus. Proin nunc erat, gravida a facilisis quis, ornare id lectus. Proin consectetur nibh quis Integer laoreet placerat suscipit. Sed sodales scelerisque commodo. Nam porta cursus lectus. Proin nunc erat, gravida a facilisis quis, ornare id lectus. Proin consectetur nibh quis urna gravid urna gravid eget erat suscipit in malesuada odio venenatis.</p>
+                    <ul>
+                        <li>
+                            test 1
+                        </li>
+                        <li>
+                            test 2
+                        </li>
+                        <li>
+                            test 3
+                        </li>
+                    </ul>
                 </div>
             </div>
         </div>
@@ -94,6 +115,17 @@
                 </div>
                 <div>
                     <p>d ut ornare non, volutpat vel tortor. Integer laoreet placerat suscipit. Sed sodales scelerisque commodo. Nam porta cursus lectus. Proin nunc erat, gravida a facilisis quis, ornare id lectus. Proin consectetur nibh quis urna gravida mollis.Suspendisse blandit velit eget erat suscipit in malesuada odio venenatis.</p>
+                    <ul>
+                        <li>
+                            test 1
+                        </li>
+                        <li>
+                            test 2
+                        </li>
+                        <li>
+                            test 3
+                        </li>
+                    </ul>
                 </div>
             </div>
         </div>

--- a/css/easy-responsive-tabs.css
+++ b/css/easy-responsive-tabs.css
@@ -1,189 +1,144 @@
-﻿body {
-    margin: 0px;
-    padding: 0px;
-    background: #f5f5f5;
-    font-family: 'Segoe UI';
-}
-ul.resp-tabs-list, p {
-    margin: 0px;
-    padding: 0px;
-}
-
-.resp-tabs-list li {
+/*
+*
+* easyResponsiveTabs.js by Samson Onna 
+*
+* https://github.com/samsono/Easy-Responsive-Tabs-to-Accordion 
+*
+*/
+/*-----------Easy Responsive Tab Base Styles-----------*/
+.resp-tabs-list {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+  @media (max-width: 768px) {
+    .resp-tabs-list {
+      display: none; } }
+  .resp-tabs-list > li {
     font-weight: 600;
     font-size: 13px;
-    display: inline-block;
-    padding: 13px 15px;
     margin: 0;
-    list-style: none;
-    cursor: pointer;
-    float: left;
-}
+    cursor: pointer; }
 
 .resp-tabs-container {
-    padding: 0px;
-    background-color: #fff;
-    clear: left;
-}
-
-h2.resp-accordion {
-    cursor: pointer;
-    padding: 5px;
-    display: none;
-}
+  padding: 0;
+  background-color: white;
+  clear: left; }
 
 .resp-tab-content {
-    display: none;
-    padding: 15px;
-}
+  display: none;
+  padding: 15px; }
 
-.resp-tab-active {
-    border: 1px solid #c1c1c1;
-    border-bottom: none;
-    margin-bottom: -1px !important;
-    padding: 12px 14px 14px 14px !important;
-}
-
-.resp-tab-active {
-    border-bottom: none;
-    background-color: #fff;
-}
-
-.resp-content-active, .resp-accordion-active {
-    display: block;
-}
-
-.resp-tab-content {
-    border: 1px solid #c1c1c1;
-}
-
-h2.resp-accordion {
-    font-size: 13px;
-    border: 1px solid #c1c1c1;
-    border-top: 0px solid #c1c1c1;
-    margin: 0px;
-    padding: 10px 15px;
-}
-
-h2.resp-tab-active {
-    border-bottom: 0px solid #c1c1c1 !important;
-    margin-bottom: 0px !important;
-    padding: 10px 15px !important;
-}
-
-h2.resp-tab-title:last-child {
-    border-bottom: 12px solid #c1c1c1 !important;
-    background: blue;
-}
-/*-----------Vertical tabs-----------*/
-.resp-vtabs ul.resp-tabs-list {
-    float: left;
-    width: 30%;
-}
-
-.resp-vtabs .resp-tabs-list li {
-    display: block;
-    padding: 15px 15px !important;
-    margin: 0;
-    cursor: pointer;
-    float: none;
-}
-
-.resp-vtabs .resp-tabs-container {
-    padding: 0px;
-    background-color: #fff;
-    border: 1px solid #c1c1c1;
-    float: left;
-    width: 68%;
-    min-height: 250px;
-    border-radius: 4px;
-    clear: none;
-}
-
-.resp-vtabs .resp-tab-content {
-    border: none;
-}
-
-.resp-vtabs li.resp-tab-active {
-    border: 1px solid #c1c1c1;
-    border-right: none;
-    background-color: #fff;
-    position: relative;
-    z-index: 1;
-    margin-right: -1px !important;
-    padding: 14px 15px 15px 14px !important;
-}
-
-.resp-arrow {
-    width: 0;
-    height: 0;
-    float: right;
-    margin-top: 3px;
-    border-left: 6px solid transparent;
-    border-right: 6px solid transparent;
-    border-top: 12px solid #c1c1c1;
-}
-
-h2.resp-tab-active span.resp-arrow {
-    border: none;
-    border-left: 6px solid transparent;
-    border-right: 6px solid transparent;
-    border-bottom: 12px solid #9B9797;
-}
-
-/*-----------Accordion styles-----------*/
-h2.resp-tab-active {
-    background: #DBDBDB !important;
-}
-.resp-easy-accordion  h2.resp-accordion {
-        display: block;
-}
-.resp-easy-accordion .resp-tab-content {
-    border: 1px solid #c1c1c1;
-}
-
-.resp-easy-accordion .resp-tab-content:last-child {
-    border-bottom: 1px solid #c1c1c1 !important;
-}
+.resp-content-active, .resp-tab-content-active {
+  display: block; }
 
 .resp-jfit {
-    width: 100%;
-    margin: 0px;
-}
+  width: 100%;
+  margin: 0; }
 
-.resp-tab-content-active {
+/*-----------Horizontal tabs-----------*/
+.resp-tabs-list > li {
+  display: inline-block;
+  padding: 13px 15px;
+  float: left; }
+
+.resp-tab-active {
+  border: 1px solid #c1c1c1;
+  border-bottom: none;
+  margin-bottom: -1px !important;
+  padding: 12px 14px 14px 14px !important;
+  border-bottom: none;
+  background-color: white; }
+
+.resp-tab-content {
+  border: 1px solid #c1c1c1; }
+
+/*-----------Vertical tabs-----------*/
+.resp-vtabs .resp-tab-item.resp-tab-active {
+  border: 1px solid #c1c1c1;
+  border-right: none;
+  background-color: white;
+  position: relative;
+  z-index: 1;
+  margin-right: -1px !important;
+  padding: 14px 15px 15px 14px !important; }
+.resp-vtabs .resp-tabs-list {
+  float: left;
+  width: 30%; }
+  .resp-vtabs .resp-tabs-list > li {
     display: block;
-}
-
-h2.resp-accordion:first-child {
-    border-top: 1px solid #c1c1c1 !important;
-}
-
-/*Here your can change the breakpoint to set the accordion, when screen resolution changed*/
-@media only screen and (max-width: 768px) {
-    ul.resp-tabs-list {
-        display: none;
-    }
-
-    h2.resp-accordion {
-        display: block;
-    }
-
-    .resp-vtabs .resp-tab-content {
-        border: 1px solid #C1C1C1;
-    }
-
+    padding: 15px !important;
+    float: none; }
+.resp-vtabs .resp-tabs-container {
+  border: 1px solid #c1c1c1;
+  float: left;
+  width: 68%;
+  min-height: 250px;
+  border-radius: 4px;
+  clear: none; }
+  @media (max-width: 768px) {
     .resp-vtabs .resp-tabs-container {
-        border: none;
-        float: none;
-        width: 100%;
-        min-height: initial;
-        clear: none;
-    }
-    .resp-accordion-closed {
-        display:none !important;
-    }
+      border: none;
+      float: none;
+      width: 100%;
+      min-height: initial;
+      clear: none; } }
+.resp-vtabs .resp-tab-content {
+  border: none; }
+  @media (max-width: 768px) {
+    .resp-vtabs .resp-tab-content {
+      border: 1px solid #c1c1c1; } }
+  @media (max-width: 768px) {
     .resp-vtabs .resp-tab-content:last-child {
-        border-bottom: 1px solid #c1c1c1 !important;
-    }
-}
+      border-bottom: 1px solid #c1c1c1 !important; } }
+
+/*-----------Accordion Styles-----------*/
+h2.resp-accordion {
+  border: 1px solid #c1c1c1;
+  cursor: pointer;
+  padding: 5px;
+  display: none;
+  font-weight: 600;
+  font-size: 13px;
+  border-top: none;
+  margin: 0px;
+  padding: 10px 15px; }
+  @media (max-width: 768px) {
+    h2.resp-accordion {
+      display: block; } }
+  h2.resp-accordion:first-child {
+    border-top: 1px solid #c1c1c1 !important; }
+
+h2.resp-tab-active {
+  background: #dbdbdb !important;
+  border-bottom: none !important;
+  margin-bottom: 0px !important;
+  padding: 10px 15px !important; }
+
+.resp-easy-accordion h2.resp-accordion {
+  display: block; }
+.resp-easy-accordion .resp-tab-content {
+  border: 1px solid #c1c1c1; }
+  .resp-easy-accordion .resp-tab-content:last-child {
+    border-bottom: 1px solid #c1c1c1 !important; }
+
+.resp-accordion-active {
+  display: block; }
+
+@media (max-width: 768px) {
+  .resp-accordion-closed {
+    display: none !important; } }
+
+.resp-arrow {
+  width: 0;
+  height: 0;
+  float: right;
+  margin-top: 3px;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 12px solid #c1c1c1; }
+
+h2.resp-tab-active span.resp-arrow {
+  border: none;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 12px solid #8e8e8e; }

--- a/sass/_accordion-styles.scss
+++ b/sass/_accordion-styles.scss
@@ -1,0 +1,74 @@
+@if $use-accordion == true{
+// Easy Responsive Tabs to Accordion
+
+/*-----------Accordion Styles-----------*/
+
+h2.resp-accordion {
+	@include common-border;
+    cursor: pointer;
+    padding: 5px;
+    display: none;
+    font-weight: $tab-font-weight;
+    font-size: $tab-font-size;
+    border-top: none;
+    margin: 0px;
+    padding: 10px 15px;
+    @include breakpoint(mq-breakpoint){
+		display: block;
+	}
+
+    &:first-child {
+    	border-top: $border-width $border-type $border-color !important;
+	}
+}
+
+h2.resp-tab-active {
+    background: $brand-sec-color !important;
+    border-bottom: none !important;
+    margin-bottom: 0px !important;
+    padding: 10px 15px !important;
+}
+
+.resp-easy-accordion {
+
+	h2.resp-accordion {
+        display: block;
+	}
+
+	.resp-tab-content {
+		@include common-border;
+
+	    &:last-child {
+	    	border-bottom: $border-width $border-type $border-color !important;
+		}
+	}
+}
+
+.resp-accordion-active {
+    display: block;
+}
+
+.resp-accordion-closed {
+	@include breakpoint(mq-breakpoint){
+		display: none !important;
+	}
+}
+
+.resp-arrow {
+    width: 0;
+    height: 0;
+    float: right;
+    margin-top: 3px;
+    border-left: ($arrow-size / 2) solid transparent;
+    border-right: ($arrow-size / 2) solid transparent;
+    border-top: $arrow-size solid $brand-pri-color;
+}
+
+h2.resp-tab-active span.resp-arrow {
+    border: none;
+    border-left: ($arrow-size / 2) solid transparent;
+    border-right: ($arrow-size / 2) solid transparent;
+    border-bottom: $arrow-size solid darken($brand-pri-color, 20%);
+}
+
+} // end if

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -1,0 +1,40 @@
+// Easy Responsive Tabs to Accordion
+
+/*-----------Easy Responsive Tab Base Styles-----------*/
+
+.resp-tabs-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	@include breakpoint(mq-breakpoint){
+		display: none;
+	}
+
+    > li {
+    	font-weight: $tab-font-weight;
+	    font-size: $tab-font-size;
+	    margin: 0;
+	    cursor: pointer;
+    }
+}
+
+.resp-tabs-container {
+	padding: 0;
+    background-color: $tab-container-color;
+    clear: left;
+}
+
+.resp-tab-content {
+    display: none;
+    padding: $content-padding;
+}
+
+.resp-content-active, .resp-tab-content-active{
+    display: block;
+}
+
+.resp-jfit {
+    width: 100%;
+    margin: 0;
+}
+

--- a/sass/_horizontal-tabs.scss
+++ b/sass/_horizontal-tabs.scss
@@ -1,0 +1,28 @@
+@if $use-horizontal-tabs == true{
+// Easy Responsive Tabs to Accordion
+
+/*-----------Horizontal tabs-----------*/
+
+.resp-tabs-list {
+
+    > li {
+    	display: inline-block;
+	    padding: 13px 15px;
+	    float: left;
+    }
+}
+
+.resp-tab-active {
+    @include common-border;
+    border-bottom: none;
+    margin-bottom: -1px !important;
+    padding: 12px 14px 14px 14px !important;
+    border-bottom: none;
+    background-color: $active-tab-color;
+}
+
+.resp-tab-content {
+	@include common-border;
+}
+
+} // end if

--- a/sass/_utility.scss
+++ b/sass/_utility.scss
@@ -1,0 +1,15 @@
+// Easy Responsive Tabs to Accordion
+//
+// ====== Utilities ======
+
+// Sets common border properties
+@mixin common-border{
+	border: $border-width $border-type $border-color; 
+}
+
+// Constructs media query for respective selector
+@mixin breakpoint($point) {
+	@if $point == mq-breakpoint { // when screen size is greater than default mobile to tablet portrait
+		@media ($mq-type: $mq-breakpoint) { @content; }
+	}
+}

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,0 +1,38 @@
+// Easy Responsive Tabs to Accordion
+//
+// ====== Variables ======
+
+// Config
+$use-horizontal-tabs: true !default;
+$use-vertical-tabs: true !default;
+$use-accordion: true !default; // be sure to remove excess markup if not using
+
+// Typography
+$tab-font-weight: 600 !default;
+$tab-font-size: 13px !default;
+
+// Colors
+$brand-pri-color: #c1c1c1;
+$brand-sec-color: #DBDBDB;
+
+// Borders
+$border-width: 1px !default;
+$border-type: solid !default;
+$border-color: $brand-pri-color;
+
+// Border Radius
+$border-radius: 4px !default;
+
+// Tabs
+$active-tab-color: #fff;
+$tab-container-color: #fff;
+
+// Padding
+$content-padding: 15px !default;
+
+// Accordion Arrows
+$arrow-size: 12px !default;
+
+// Media Query Breakpoint
+$mq-type: max-width;
+$mq-breakpoint: 768px;

--- a/sass/_vertical-styles.scss
+++ b/sass/_vertical-styles.scss
@@ -1,0 +1,63 @@
+@if $use-vertical-tabs == true{
+// Easy Responsive Tabs to Accordion
+//
+// ====== Vertical Tab Styles ======
+
+/*-----------Vertical tabs-----------*/
+.resp-vtabs {
+
+	.resp-tab-item {
+
+		&.resp-tab-active {
+			@include common-border;
+		    border-right: none;
+		    background-color: $active-tab-color;
+		    position: relative;
+		    z-index: 1;
+		    margin-right: -1px !important;
+		    padding: 14px 15px 15px 14px !important;
+		}
+	}
+
+	.resp-tabs-list {
+	    float: left;
+	    width: 30%;
+
+	    > li {
+		    display: block;
+		    padding: 15px !important;
+		    float: none;
+		}
+	}
+
+	.resp-tabs-container {
+		@include common-border;
+	    float: left;
+	    width: 68%;
+	    min-height: 250px;
+	    border-radius: $border-radius;
+	    clear: none;
+	    @include breakpoint(mq-breakpoint){
+			border: none;
+	        float: none;
+	        width: 100%;
+	        min-height: initial;
+	        clear: none;
+		}
+	}
+
+	.resp-tab-content {
+	    border: none;
+	    @include breakpoint(mq-breakpoint){
+			@include common-border;
+		}
+
+		&:last-child{
+			@include breakpoint(mq-breakpoint){
+				border-bottom: $border-width $border-type $border-color !important;
+			}
+		}
+	}
+}
+
+} // end if

--- a/sass/easy-responsive-tabs.scss
+++ b/sass/easy-responsive-tabs.scss
@@ -1,0 +1,29 @@
+/*!
+*
+* easyResponsiveTabs.js by Samson Onna 
+*
+* https://github.com/samsono/Easy-Responsive-Tabs-to-Accordion 
+*
+*/
+
+// Easy Responsive Tabs to Accordion
+
+// ====== Import All Styles ======
+
+// Set the configuration and styles
+@import "variables";
+
+// Mixins utilities
+@import "utility";
+
+// Base tab styles used by all tab types
+@import "base";
+
+// Horizontal tab specific styles
+@import "horizontal-tabs";
+
+// Vertical tab specific styles
+@import "vertical-styles";
+
+// Accordion specific styles
+@import "accordion-styles";


### PR DESCRIPTION
Converted CSS to Sass/SCSS for easier import into Sass projects, abstraction for easier theming, configuration for usage variation. Cleaned up repetitive/loose styles. Moved body styles to demo index styles. Configurable sass to turn on/off horiztontal/vertical/accordion styles.
