### PR TITLE
Added any Data attributes from tab to Accordion

### DIFF
--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -55,8 +55,10 @@
                 var itemCount = 0;
                 $respTabs.find('.resp-accordion').each(function () {
                     $tabItemh2 = $(this);
-                    var innertext = $respTabs.find('.resp-tab-item:eq(' + itemCount + ')').html();
-                    $respTabs.find('.resp-accordion:eq(' + itemCount + ')').append(innertext);
+                    var $tabItem = $respTabs.find('.resp-tab-item:eq(' + itemCount + ')');
+                    var $accItem = $respTabs.find('.resp-accordion:eq(' + itemCount + ')');
+                    $accItem.append($tabItem.html());
+                    $accItem.data($tabItem.data());
                     $tabItemh2.attr('aria-controls', 'tab_item-' + (itemCount));
                     itemCount++;
                 });


### PR DESCRIPTION
So if you have the following code:

``` html
    <div id="demoTab">          
        <ul class="resp-tabs-list">
            <li data-type="fish">Shark</li>
            <li data-type="fish">Tuna</li>
            <li data-type="mammal">Whale</li>
        </ul> 

        <div class="resp-tabs-container">                                                        
            <div>Shark facts</div>
            <div>Tuna Facts</div>
            <div>Whale Facts</div>
        </div>
    </div>    
```

Then the `data("type")` attribute is now honored on both the accordion and the tab

``` javascript
$('#demoTab').easyResponsiveTabs({
   activate: function (e) {
       console.log($(e.target).data("type"));
   }
});
```

Before the above would output `undefined` when running in accordion mode. Now it outputs the data type assigned to that tab.
