### PR TITLE
Created a new event "activate"

### DIFF
--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -88,9 +88,9 @@
 
                 //Tab Click action function
                 $respTabs.find("[role=tab]").each(function () {
-                    var $currentTab = $(this);
-                    $currentTab.click(function () {
+                    $currentTab.bind("click activate", function () {
 
+                        var $currentTab = $(this);
                         var $tabAria = $currentTab.attr('aria-controls');
 
                         if ($currentTab.hasClass('resp-accordion') && $currentTab.hasClass('resp-tab-active')) {
@@ -113,10 +113,12 @@
                         //Trigger tab activation event
                         $currentTab.trigger('tabactivate', $currentTab);
                     });
-                    //Window resize function                   
-                    $(window).resize(function () {
-                        $respTabs.find('.resp-accordion-closed').removeAttr('style');
-                    });
+                    
+                });
+                
+                //Window resize function                   
+                $(window).resize(function () {
+                    $respTabs.find('.resp-accordion-closed').removeAttr('style');
                 });
             });
         }


### PR DESCRIPTION
The "activate" function allows people to click a tab through code.

Now you can use the following to essentially "click" a tab:

``` javascript
$('#tabs').find('[role="tab"]').first().trigger("activate")
```

I've also removed the duplicate binding of the "resize" function (only
needs to be bound once outside the loop)
