### PR TITLE
Hash improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Features
 + Supports multiple sets of tabs on same page
 + Cross browser compatibility (IE7+, Chrome, Firefox, Safari and Opera)
 + Multi device support (Web, Tablets & Mobile)
++ Link directly to specified tab (works with multiple instances)
++ Maintains state of tabs when navigating away from page and then returning using back or forward (if browser supports the History API)
 
 Demo
 ====
@@ -56,6 +58,14 @@ How to use
             activate: function() {}  // Callback function, gets called if tab is switched
         });
 
+=> Linking to Tabs:
+        
+        http://yoursite.com/tabs.html#{TAB ID}{TAB NUM}
+        http://yoursite.com/tabs.html#demoTab2
+        
+        Multiple Instances:
+        http://yoursite.com/tabs.html#{TAB ID 1}{TAB NUM}|{TAB ID 2}{TAB NUM}
+        http://yoursite.com/tabs.html#demoTab2|demoTwo3
 
 For any support
 ===============

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -72,13 +72,6 @@
                     $tabItem.attr('aria-controls', 'tab_item-' + (count));
                     $tabItem.attr('role', 'tab');
 
-                    //First active tab, keep closed if option = 'closed' or option is 'accordion' and the element is in accordion mode 
-                    if(options.closed !== true && !(options.closed === 'accordion' && !$respTabsList.is(':visible')) && !(options.closed === 'tabs' && $respTabsList.is(':visible'))) {                  
-                        $respTabs.find('.resp-tab-item').first().addClass('resp-tab-active');
-                        $respTabs.find('.resp-accordion').first().addClass('resp-tab-active');
-                        $respTabs.find('.resp-tab-content').first().addClass('resp-tab-content-active').attr('style', 'display:block');
-                    }
-
                     //Assigning the 'aria-labelledby' attr to tab-content
                     var tabcount = 0;
                     $respTabs.find('.resp-tab-content').each(function () {
@@ -88,6 +81,26 @@
                     });
                     count++;
                 });
+                
+                //Determine what tab to show
+                var tabNum = 0;
+                if (hash.indexOf(respTabsId)>-1) {
+                    tabNum = ((hash.replace('#'+respTabsId,''))*1)-1;
+                    tabNum = tabNum > -1 && tabNum < count+1 ? tabNum : 0;
+                }
+
+                //Active correct tab
+                $($respTabs.find('.resp-tab-item')[tabNum]).addClass('resp-tab-active');
+
+                //keep closed if option = 'closed' or option is 'accordion' and the element is in accordion mode
+                if(options.closed !== true && !(options.closed === 'accordion' && !$respTabsList.is(':visible')) && !(options.closed === 'tabs' && $respTabsList.is(':visible'))) {                  
+                    $($respTabs.find('.resp-accordion')[tabNum]).addClass('resp-tab-active');
+                    $($respTabs.find('.resp-tab-content')[tabNum]).addClass('resp-tab-content-active').attr('style', 'display:block');
+                }
+                //assign proper classes for when tabs mode is activated before making a selection in accordion mode
+                else {
+                    $($respTabs.find('.resp-tab-content')[tabNum]).addClass('resp-tab-content-active resp-accordion-closed')
+                }
 
                 //Tab Click action function
                 $respTabs.find("[role=tab]").each(function () {

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -14,7 +14,9 @@
             //Variables
             var options = $.extend(defaults, options);            
             var opt = options, jtype = opt.type, jfit = opt.fit, jwidth = opt.width, vtabs = 'vertical', accord = 'accordion';
-
+            var hash = window.location.hash;
+            var historyApi = !!(window.history && history.replaceState);
+            
             //Events
             $(this).bind('tabactivate', function(e, currentTab) {
                 if(typeof options.activate === 'function') {
@@ -26,6 +28,7 @@
             this.each(function () {
                 var $respTabs = $(this);
                 var $respTabsList = $respTabs.find('ul.resp-tabs-list');
+                var respTabsId = $respTabs.attr('id');
                 $respTabs.find('ul.resp-tabs-list li').addClass('resp-tab-item');
                 $respTabs.css({
                     'display': 'block',
@@ -112,6 +115,11 @@
                         }
                         //Trigger tab activation event
                         $currentTab.trigger('tabactivate', $currentTab);
+                        
+                        //Update Browser History
+                        if(historyApi) {
+                            history.replaceState(null,null,'#'+respTabsId+(parseInt($tabAria.substring(9))+1).toString());
+                        }
                     });
                     //Window resize function                   
                     $(window).resize(function () {

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -82,11 +82,16 @@
                     count++;
                 });
                 
-                //Determine what tab to show
+                // Show correct content area
                 var tabNum = 0;
-                if (hash.indexOf(respTabsId)>-1) {
-                    tabNum = ((hash.replace('#'+respTabsId,''))*1)-1;
-                    tabNum = tabNum > -1 && tabNum < count+1 ? tabNum : 0;
+                if(hash!='') {
+                    var matches = hash.match(new RegExp(respTabsId+"([0-9]+)"));
+                    if (matches!==null && matches.length===2) {
+                        tabNum = parseInt(matches[1],10)-1;
+                        if (tabNum > count) {
+                            tabNum = 0;
+                        }
+                    }
                 }
 
                 //Active correct tab
@@ -131,7 +136,22 @@
                         
                         //Update Browser History
                         if(historyApi) {
-                            history.replaceState(null,null,'#'+respTabsId+(parseInt($tabAria.substring(9))+1).toString());
+                            var currentHash = window.location.hash;
+                            var newHash = respTabsId+(parseInt($tabAria.substring(9),10)+1).toString();
+                            if (currentHash!="") {
+                                var re = new RegExp(respTabsId+"[0-9]+");
+                                if (currentHash.match(re)!=null) {                                    
+                                    newHash = currentHash.replace(re,newHash);
+                                }
+                                else {
+                                    newHash = currentHash+"|"+newHash;
+                                }
+                            }
+                            else {
+                                newHash = '#'+newHash;
+                            }
+                            
+                            history.replaceState(null,null,newHash);
                         }
                     });
                     //Window resize function                   


### PR DESCRIPTION
Added the ability to link directly to tabs based on the hash tag. Also, the script now updates the state of the tabs when they are clicked using the History API. There is a check for support for the History API and then is utilized if supported. If there isn't support, no fall back is used.

I also made some changes to the attaching of the active tab classes. First, they were located in aria tab declarations loop and were being assigned multiple times when they only needed to be applied once. In addition, when the accordion parameter was set as closed, if you expanded out to desktop mode the content regions were all hidden. So i made sure that resp-tab-content-active and resp-accordion-closed classes were applied to either the first region or the one specified in the hash.
