### PR TITLE
'tabactivate' event fix

### DIFF
--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -109,6 +109,9 @@
                     $($respTabs.find('.resp-tab-content')[tabNum]).addClass('resp-tab-content-active resp-accordion-closed')
                 }
 
+                //fire tabactivate event after set active tab
+                $($respTabs.find('.resp-tab-item')[tabNum]).trigger('tabactivate');
+
                 //Tab Click action function
                 $respTabs.find("[role=tab]").each(function () {
                    


### PR DESCRIPTION
- add triggering 'tabactivate' event after load page with certain tab (for example, with parameter #verticalTab2)
