### PR TITLE
added headingTag to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ How to use
 
         $("#demoTab").easyResponsiveTabs({
             type: 'default', //Types: default, vertical, accordion           
-            width: 'auto', //auto or any custom width
+            width: 'auto', // auto or any custom width
             fit: true,   // 100% fits in a container
             closed: false, // Close the panels on start, the options 'accordion' and 'tabs' keep them closed in there respective view types
+            headingTag: 'h2', // specify which level of heading to assign to the tab element
             activate: function() {}  // Callback function, gets called if tab is switched
         });
 

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -9,6 +9,7 @@
                 width: 'auto',
                 fit: true,
                 closed: false,
+                headingTag: 'h2',
                 activate: function(){}
             }
             //Variables
@@ -51,18 +52,19 @@
                     }
                 }
 
-                //Assigning the h2 markup to accordion title
-                var $tabItemh2;
-                $respTabs.find('.resp-tab-content').before("<h2 class='resp-accordion' role='tab'><span class='resp-arrow'></span></h2>");
+                //Assigning the heading markup to accordion title
+                var $tabItemHeading,
+                    $tabItemHeadingMarkup = '<' + options.headingTag + ' class="resp-accordion" role="tab"><span class="resp-arrow"></span></' + options.headingTag + '>';
+                $respTabs.find('.resp-tab-content').before($tabItemHeadingMarkup);
 
                 var itemCount = 0;
                 $respTabs.find('.resp-accordion').each(function () {
-                    $tabItemh2 = $(this);
+                    $tabItemHeading = $(this);
                     var $tabItem = $respTabs.find('.resp-tab-item:eq(' + itemCount + ')');
                     var $accItem = $respTabs.find('.resp-accordion:eq(' + itemCount + ')');
                     $accItem.append($tabItem.html());
                     $accItem.data($tabItem.data());
-                    $tabItemh2.attr('aria-controls', 'tab_item-' + (itemCount));
+                    $tabItemHeading.attr('aria-controls', 'tab_item-' + (itemCount));
                     itemCount++;
                 });
 


### PR DESCRIPTION
Having an `<h2>` hardcoded as the tab element might not be appropriate in some content, so I've added a `headingTag` parameter to options array. It defaults to `'h2'` as before, but you can now specify your own heading level for the tab elements (`'h3'`, for instance).
