### PR TITLE
Adding option to give tabs custom Ids and to turn off URL hash and browser history manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ How to use
             <ul class="resp-tabs-list">
                 <li> .... </li>
                 <li> .... </li>
-                <li> .... </li>
+                <li id="ThisTabHasACustomId"> .... </li>
             </ul> 
 
             <div class="resp-tabs-container">                                                        
@@ -55,6 +55,7 @@ How to use
             width: 'auto', //auto or any custom width
             fit: true,   // 100% fits in a container
             closed: false, // Close the panels on start, the options 'accordion' and 'tabs' keep them closed in there respective view types
+            updateHistory: true, // supporting browsers will update browser history and URL hash with the selected tab (this is the default)
             activate: function() {}  // Callback function, gets called if tab is switched
         });
 

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -1,14 +1,5 @@
-// This is a fork of the Easy Responsive Tabs Plugin
-// Fork author: Ben Griffiths
-/*
- * Added in this fork:
- * 
- * (1) Added updateHistory as a boolean option, and turned off history API and URL hash manipulation by default
- * 
- */
-
-// Original author: Samson.Onna <Email : samson3d@gmail.com>
-
+// Easy Responsive Tabs Plugin
+// Author: Samson.Onna <Email : samson3d@gmail.com>
 (function ($) {
     $.fn.extend({
         easyResponsiveTabs: function (options) {
@@ -18,15 +9,14 @@
                 width: 'auto',
                 fit: true,
                 closed: false,
-                updateHistory: false, //Do not update browser history and URL hash by default
                 activate: function(){}
             }
             //Variables
-            var options = $.extend(defaults, options);
+            var options = $.extend(defaults, options);            
             var opt = options, jtype = opt.type, jfit = opt.fit, jwidth = opt.width, vtabs = 'vertical', accord = 'accordion';
             var hash = window.location.hash;
             var historyApi = !!(window.history && history.replaceState);
-
+            
             //Events
             $(this).bind('tabactivate', function(e, currentTab) {
                 if(typeof options.activate === 'function') {
@@ -93,7 +83,7 @@
                     });
                     count++;
                 });
-
+                
                 // Show correct content area
                 var tabNum = 0;
                 if(hash!='') {
@@ -110,21 +100,21 @@
                 $($respTabs.find('.resp-tab-item')[tabNum]).addClass('resp-tab-active');
 
                 //keep closed if option = 'closed' or option is 'accordion' and the element is in accordion mode
-                if(options.closed !== true && !(options.closed === 'accordion' && !$respTabsList.is(':visible')) && !(options.closed === 'tabs' && $respTabsList.is(':visible'))) {
+                if(options.closed !== true && !(options.closed === 'accordion' && !$respTabsList.is(':visible')) && !(options.closed === 'tabs' && $respTabsList.is(':visible'))) {                  
                     $($respTabs.find('.resp-accordion')[tabNum]).addClass('resp-tab-active');
                     $($respTabs.find('.resp-tab-content')[tabNum]).addClass('resp-tab-content-active').attr('style', 'display:block');
                 }
-                    //assign proper classes for when tabs mode is activated before making a selection in accordion mode
+                //assign proper classes for when tabs mode is activated before making a selection in accordion mode
                 else {
                     $($respTabs.find('.resp-tab-content')[tabNum]).addClass('resp-tab-content-active resp-accordion-closed')
                 }
 
                 //Tab Click action function
                 $respTabs.find("[role=tab]").each(function () {
-
+                   
                     var $currentTab = $(this);
                     $currentTab.click(function () {
-
+                        
                         var $currentTab = $(this);
                         var $tabAria = $currentTab.attr('aria-controls');
 
@@ -147,14 +137,14 @@
                         }
                         //Trigger tab activation event
                         $currentTab.trigger('tabactivate', $currentTab);
-
+                        
                         //Update Browser History
-                        if (options.updateHistory && historyApi) {
+                        if(historyApi) {
                             var currentHash = window.location.hash;
                             var newHash = respTabsId+(parseInt($tabAria.substring(9),10)+1).toString();
                             if (currentHash!="") {
                                 var re = new RegExp(respTabsId+"[0-9]+");
-                                if (currentHash.match(re)!=null) {
+                                if (currentHash.match(re)!=null) {                                    
                                     newHash = currentHash.replace(re,newHash);
                                 }
                                 else {
@@ -164,13 +154,13 @@
                             else {
                                 newHash = '#'+newHash;
                             }
-
+                            
                             history.replaceState(null,null,newHash);
                         }
                     });
-
+                    
                 });
-
+                
                 //Window resize function                   
                 $(window).resize(function () {
                     $respTabs.find('.resp-accordion-closed').removeAttr('style');

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -1,9 +1,9 @@
 // This is a fork of the Easy Responsive Tabs Plugin
-
+// Fork author: Ben Griffiths
 /*
  * Added in this fork:
  * 
- * (1) Added updateHistory as a boolean option to allow use of history API and URL hash manipulation to be turned off
+ * (1) Added updateHistory as a boolean option, and turned off history API and URL hash manipulation by default
  * 
  */
 
@@ -18,7 +18,7 @@
                 width: 'auto',
                 fit: true,
                 closed: false,
-                updateHistory: true,
+                updateHistory: false, //Do not update browser history and URL hash by default
                 activate: function(){}
             }
             //Variables

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -1,5 +1,14 @@
-// Easy Responsive Tabs Plugin
-// Author: Samson.Onna <Email : samson3d@gmail.com>
+// This is a fork of the Easy Responsive Tabs Plugin
+// Fork author: Ben Griffiths
+/*
+ * Added in this fork:
+ * 
+ * (1) Added updateHistory as a boolean option, and turned off history API and URL hash manipulation by default
+ * 
+ */
+
+// Original author: Samson.Onna <Email : samson3d@gmail.com>
+
 (function ($) {
     $.fn.extend({
         easyResponsiveTabs: function (options) {
@@ -9,14 +18,15 @@
                 width: 'auto',
                 fit: true,
                 closed: false,
+                updateHistory: false, //Do not update browser history and URL hash by default
                 activate: function(){}
             }
             //Variables
-            var options = $.extend(defaults, options);            
+            var options = $.extend(defaults, options);
             var opt = options, jtype = opt.type, jfit = opt.fit, jwidth = opt.width, vtabs = 'vertical', accord = 'accordion';
             var hash = window.location.hash;
             var historyApi = !!(window.history && history.replaceState);
-            
+
             //Events
             $(this).bind('tabactivate', function(e, currentTab) {
                 if(typeof options.activate === 'function') {
@@ -83,7 +93,7 @@
                     });
                     count++;
                 });
-                
+
                 // Show correct content area
                 var tabNum = 0;
                 if(hash!='') {
@@ -100,21 +110,21 @@
                 $($respTabs.find('.resp-tab-item')[tabNum]).addClass('resp-tab-active');
 
                 //keep closed if option = 'closed' or option is 'accordion' and the element is in accordion mode
-                if(options.closed !== true && !(options.closed === 'accordion' && !$respTabsList.is(':visible')) && !(options.closed === 'tabs' && $respTabsList.is(':visible'))) {                  
+                if(options.closed !== true && !(options.closed === 'accordion' && !$respTabsList.is(':visible')) && !(options.closed === 'tabs' && $respTabsList.is(':visible'))) {
                     $($respTabs.find('.resp-accordion')[tabNum]).addClass('resp-tab-active');
                     $($respTabs.find('.resp-tab-content')[tabNum]).addClass('resp-tab-content-active').attr('style', 'display:block');
                 }
-                //assign proper classes for when tabs mode is activated before making a selection in accordion mode
+                    //assign proper classes for when tabs mode is activated before making a selection in accordion mode
                 else {
                     $($respTabs.find('.resp-tab-content')[tabNum]).addClass('resp-tab-content-active resp-accordion-closed')
                 }
 
                 //Tab Click action function
                 $respTabs.find("[role=tab]").each(function () {
-                   
+
                     var $currentTab = $(this);
                     $currentTab.click(function () {
-                        
+
                         var $currentTab = $(this);
                         var $tabAria = $currentTab.attr('aria-controls');
 
@@ -137,14 +147,14 @@
                         }
                         //Trigger tab activation event
                         $currentTab.trigger('tabactivate', $currentTab);
-                        
+
                         //Update Browser History
-                        if(historyApi) {
+                        if (options.updateHistory && historyApi) {
                             var currentHash = window.location.hash;
                             var newHash = respTabsId+(parseInt($tabAria.substring(9),10)+1).toString();
                             if (currentHash!="") {
                                 var re = new RegExp(respTabsId+"[0-9]+");
-                                if (currentHash.match(re)!=null) {                                    
+                                if (currentHash.match(re)!=null) {
                                     newHash = currentHash.replace(re,newHash);
                                 }
                                 else {
@@ -154,13 +164,13 @@
                             else {
                                 newHash = '#'+newHash;
                             }
-                            
+
                             history.replaceState(null,null,newHash);
                         }
                     });
-                    
+
                 });
-                
+
                 //Window resize function                   
                 $(window).resize(function () {
                     $respTabs.find('.resp-accordion-closed').removeAttr('style');

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -9,6 +9,7 @@
                 width: 'auto',
                 fit: true,
                 closed: false,
+                updateHistory: true, // update the URL hash and browser history when tab is selected
                 activate: function(){}
             }
             //Variables
@@ -139,7 +140,7 @@
                         $currentTab.trigger('tabactivate', $currentTab);
                         
                         //Update Browser History
-                        if(historyApi) {
+                        if(options.updateHistory && historyApi) {
                             var currentHash = window.location.hash;
                             var newHash = respTabsId+(parseInt($tabAria.substring(9),10)+1).toString();
                             if (currentHash!="") {

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -1,9 +1,9 @@
 // This is a fork of the Easy Responsive Tabs Plugin
-// Fork author: Ben Griffiths
+
 /*
  * Added in this fork:
  * 
- * (1) Added updateHistory as a boolean option, and turned off history API and URL hash manipulation by default
+ * (1) Added updateHistory as a boolean option to allow use of history API and URL hash manipulation to be turned off
  * 
  */
 
@@ -18,7 +18,7 @@
                 width: 'auto',
                 fit: true,
                 closed: false,
-                updateHistory: false, //Do not update browser history and URL hash by default
+                updateHistory: true,
                 activate: function(){}
             }
             //Variables

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -3,8 +3,8 @@
 /*
  * Added in this fork:
  * 
- * (1) Added updateHistory as a boolean option so that tabs can be used without updating browser history
- * (2) Updated URL hash algorithm to use id on list item if present
+ * (1) Added updateHistory as a boolean option to allow use of history API and URL hash manipulation to be turned off
+ * 
  */
 
 // Original author: Samson.Onna <Email : samson3d@gmail.com>
@@ -78,18 +78,11 @@
 
                 //Assigning the 'aria-controls' to Tab items
                 var count = 0,
-                    $tabContent,
-                    usingIds = false,
-                    $tabItems = $respTabs.find('.resp-tab-item');
-
-                $tabItems.each(function () {
+                    $tabContent;
+                $respTabs.find('.resp-tab-item').each(function () {
                     $tabItem = $(this);
                     $tabItem.attr('aria-controls', 'tab_item-' + (count));
                     $tabItem.attr('role', 'tab');
-
-                    if ($(this).attr('id')) {
-                        usingIds = true;
-                    }
 
                     //Assigning the 'aria-labelledby' attr to tab-content
                     var tabcount = 0;
@@ -100,18 +93,6 @@
                     });
                     count++;
                 });
-
-                //If some but not all of the tab items have an Id, add any missing Ids,
-                //which we will use to identify tabs when updating the browser history
-                if (usingIds) {
-                    count = 1;
-                    $tabItems.each(function () {
-                        if (!$(this).attr('id')) {
-                            $(this).attr('id', respTabsId + count);
-                        }
-                        count++;
-                    });
-                }
 
                 // Show correct content area
                 var tabNum = 0;
@@ -169,51 +150,22 @@
 
                         //Update Browser History
                         if (options.updateHistory && historyApi) {
-
-                            var $tabHeader = $respTabs.find('.resp-tab-item[aria-controls=' + $tabAria + ']'),
-                                currentHash = window.location.hash,
-                                updateHashBasedOnIdOfAnotherTab = function (newHashFragment) {
-                                    var updatedHash = null;
-                                    $.each($tabItems, function () {
-                                        var thisId;
-                                        if (!updatedHash) {
-                                            thisId = $(this).attr('id');
-                                            if (currentHash.indexOf('#' + thisId) !== -1 || currentHash.indexOf('|' + thisId) !== -1) {
-                                                updatedHash = currentHash.replace(thisId, newHashFragment);
-                                            }
-                                        }
-                                    });
-                                    return updatedHash;
-                                },
-                                getNewHashBasedOnTabNumber = function () {
-                                    var hash = respTabsId + (parseInt($tabAria.substring(9), 10) + 1).toString();
-                                    if (currentHash != "") {
-                                        var re = new RegExp(respTabsId + "[0-9]+");
-                                        if (currentHash.match(re) != null) {
-                                            return currentHash.replace(re, hash);
-                                        }
-                                        else {
-                                            return updateHashBasedOnIdOfAnotherTab(hash) || (currentHash + '|' + hash);
-                                        }
-                                    }
-                                    else {
-                                        return '#' + hash;
-                                    }
-                                },
-                                getNewHashBasedOnTabItemId = function () {
-                                    var id = $tabHeader.attr('id');
-                                    if (id) {
-                                        return updateHashBasedOnIdOfAnotherTab(id) || id;
-                                    }
-                                    return false;
-                                },
-                                newHash = getNewHashBasedOnTabItemId() || getNewHashBasedOnTabNumber();
-
-                            if (newHash.indexOf('#') !== 0) {
-                                newHash = '#' + newHash;
+                            var currentHash = window.location.hash;
+                            var newHash = respTabsId+(parseInt($tabAria.substring(9),10)+1).toString();
+                            if (currentHash!="") {
+                                var re = new RegExp(respTabsId+"[0-9]+");
+                                if (currentHash.match(re)!=null) {
+                                    newHash = currentHash.replace(re,newHash);
+                                }
+                                else {
+                                    newHash = currentHash+"|"+newHash;
+                                }
+                            }
+                            else {
+                                newHash = '#'+newHash;
                             }
 
-                            history.replaceState(null, null, newHash);
+                            history.replaceState(null,null,newHash);
                         }
                     });
 

--- a/js/easyResponsiveTabs.js
+++ b/js/easyResponsiveTabs.js
@@ -3,8 +3,8 @@
 /*
  * Added in this fork:
  * 
- * (1) Added updateHistory as a boolean option to allow use of history API and URL hash manipulation to be turned off
- * 
+ * (1) Added updateHistory as a boolean option so that tabs can be used without updating browser history
+ * (2) Updated URL hash algorithm to use id on list item if present
  */
 
 // Original author: Samson.Onna <Email : samson3d@gmail.com>
@@ -78,11 +78,18 @@
 
                 //Assigning the 'aria-controls' to Tab items
                 var count = 0,
-                    $tabContent;
-                $respTabs.find('.resp-tab-item').each(function () {
+                    $tabContent,
+                    usingIds = false,
+                    $tabItems = $respTabs.find('.resp-tab-item');
+
+                $tabItems.each(function () {
                     $tabItem = $(this);
                     $tabItem.attr('aria-controls', 'tab_item-' + (count));
                     $tabItem.attr('role', 'tab');
+
+                    if ($(this).attr('id')) {
+                        usingIds = true;
+                    }
 
                     //Assigning the 'aria-labelledby' attr to tab-content
                     var tabcount = 0;
@@ -93,6 +100,18 @@
                     });
                     count++;
                 });
+
+                //If some but not all of the tab items have an Id, add any missing Ids,
+                //which we will use to identify tabs when updating the browser history
+                if (usingIds) {
+                    count = 1;
+                    $tabItems.each(function () {
+                        if (!$(this).attr('id')) {
+                            $(this).attr('id', respTabsId + count);
+                        }
+                        count++;
+                    });
+                }
 
                 // Show correct content area
                 var tabNum = 0;
@@ -150,22 +169,51 @@
 
                         //Update Browser History
                         if (options.updateHistory && historyApi) {
-                            var currentHash = window.location.hash;
-                            var newHash = respTabsId+(parseInt($tabAria.substring(9),10)+1).toString();
-                            if (currentHash!="") {
-                                var re = new RegExp(respTabsId+"[0-9]+");
-                                if (currentHash.match(re)!=null) {
-                                    newHash = currentHash.replace(re,newHash);
-                                }
-                                else {
-                                    newHash = currentHash+"|"+newHash;
-                                }
-                            }
-                            else {
-                                newHash = '#'+newHash;
+
+                            var $tabHeader = $respTabs.find('.resp-tab-item[aria-controls=' + $tabAria + ']'),
+                                currentHash = window.location.hash,
+                                updateHashBasedOnIdOfAnotherTab = function (newHashFragment) {
+                                    var updatedHash = null;
+                                    $.each($tabItems, function () {
+                                        var thisId;
+                                        if (!updatedHash) {
+                                            thisId = $(this).attr('id');
+                                            if (currentHash.indexOf('#' + thisId) !== -1 || currentHash.indexOf('|' + thisId) !== -1) {
+                                                updatedHash = currentHash.replace(thisId, newHashFragment);
+                                            }
+                                        }
+                                    });
+                                    return updatedHash;
+                                },
+                                getNewHashBasedOnTabNumber = function () {
+                                    var hash = respTabsId + (parseInt($tabAria.substring(9), 10) + 1).toString();
+                                    if (currentHash != "") {
+                                        var re = new RegExp(respTabsId + "[0-9]+");
+                                        if (currentHash.match(re) != null) {
+                                            return currentHash.replace(re, hash);
+                                        }
+                                        else {
+                                            return updateHashBasedOnIdOfAnotherTab(hash) || (currentHash + '|' + hash);
+                                        }
+                                    }
+                                    else {
+                                        return '#' + hash;
+                                    }
+                                },
+                                getNewHashBasedOnTabItemId = function () {
+                                    var id = $tabHeader.attr('id');
+                                    if (id) {
+                                        return updateHashBasedOnIdOfAnotherTab(id) || id;
+                                    }
+                                    return false;
+                                },
+                                newHash = getNewHashBasedOnTabItemId() || getNewHashBasedOnTabNumber();
+
+                            if (newHash.indexOf('#') !== 0) {
+                                newHash = '#' + newHash;
                             }
 
-                            history.replaceState(null,null,newHash);
+                            history.replaceState(null, null, newHash);
                         }
                     });
 


### PR DESCRIPTION
Hi,

I've been trying out your plugin in a couple of projects and it's awesome.

I've made a couple of additions to the browser history side of things - it can now be turned off in the options, and if it is left on, you can give tabs custom Ids for use in the URL hash by applying id attributes to the list item elements in the html.

Hopefully these additions might be useful for others too? Sorry about the three reverted commits! I was trying out the git plugin for Visual Studio and it was messing up the encoding of files and thus mangling the diffs, so I ended up reverting and re-applying my changes from scratch.

Ben
